### PR TITLE
Automatic Export of Env Variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,17 @@
 # Define default environment variables
 INFO=true
 
+# Read the .env file and export variables using xargs
+export_env:
+	export $(cat .env | xargs -n 1) && echo "Environment variables exported."
+
+# Default target
+.PHONY: run
+
 # Normal mode (INFO only)
-run:
+run: export_env
 	@INFO=$(INFO) streamlit run app.py
 
 # Debug mode (INFO and DEBUG)
-debug:
+debug: export_env
 	@DEBUG=true INFO=$(INFO) streamlit run app.py


### PR DESCRIPTION
To manage secrets, the environment variables are leveraged using `.env` file which is Git-ignored - for obvious reasons.

At the time of writing, the format of the `.env` file is like:

```bash
MEDIASTACK_API_KEY=<mediastack_secret_api_key>
```

Other Env variables are managed expressly for Streamlit, using its secret storage.